### PR TITLE
display alternative languages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ DefaultContentLanguage = "en"
 
 [params]
     disableReadmoreNav = true
-    menushortcutsnewtab = true
+    menushortcutsnewtab = false
     custom_js = ["js/custom.js"]
     custom_css = ["scss/custom.scss"]
     images = ["images/btctranscripts.png"]
@@ -39,7 +39,27 @@ DefaultContentLanguage = "en"
   [markup.goldmark.renderer]
     unsafe = true
 
-[[menu.shortcuts]]
-    name = "<i class='fab fa-github'></i>"
-    url = "https://github.com/bitcointranscripts/bitcointranscripts"
+[[languages.en.menu.shortcuts]]
+    name = "es"
+    url = "/es"
     weight = 1
+[[languages.en.menu.shortcuts]]
+    name = "pt"
+    url = "/pt"
+    weight = 2
+[[languages.es.menu.shortcuts]]
+    name = "en"
+    url = "/en"
+    weight = 1
+[[languages.es.menu.shortcuts]]
+    name = "pt"
+    url = "/pt"
+    weight = 2
+[[languages.pt.menu.shortcuts]]
+    name = "en"
+    url = "/en"
+    weight = 1
+[[languages.pt.menu.shortcuts]]
+    name = "es"
+    url = "/es"
+    weight = 2

--- a/themes/ace-documentation/layouts/partials/header.html
+++ b/themes/ace-documentation/layouts/partials/header.html
@@ -24,6 +24,12 @@
                                 </a>
                             </li>
                         {{- end}}
+                            <!-- GitHub menu item is constant for all languages -->
+                            <li class="nav-item">
+                                <a class="nav-link" href="https://github.com/bitcointranscripts/bitcointranscripts" target="_blank">
+                                    <i class='fab fa-github'></i>
+                                </a>
+                            </li>
                   {{- end}}
               </ul>
             </div>


### PR DESCRIPTION
Fixes #37 by displaying the alternative languages
as navigation bar menu shortcuts

![demo-lng](https://user-images.githubusercontent.com/18506343/160460252-d6770f7e-878b-40c9-9105-45a045907d37.gif)

