### PR TITLE
add speakers taxonomy and date support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,11 @@ ignoreFiles = [ "README.md", "LICENSE.md" ]
 
 DefaultContentLanguage = "en"
 
+[taxonomies]
+  category = 'categories'
+  tag = 'tags'
+  speaker = 'speakers'
+
 [languages]
   [languages.en]
     title = "₿itcoin Transcripts"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -3,6 +3,8 @@ categories = "categories"
 tags = "tags"
 translation_by = "translation by"
 transcript_by = "transcript by"
+speakers = "speakers"
+date = "date"
 
 lead = "A treasure trove of transcripts associated with Bitcoin and Lightning Network"
 section1_title = "Bitcoin Archeology"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -3,6 +3,8 @@ categories = "categorías"
 tags = "tags"
 translation_by = "traducción por"
 transcript_by = "transcripción de"
+speakers = "oradores"
+date = "fecha"
 
 lead = "Un tesoro de transcripciones asociadas con Bitcoin y Lightning Network"
 section1_title = "Arqueología de Bitcoin"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -3,6 +3,8 @@ categories = "categorias"
 tags = "tags"
 translation_by = "tradução por"
 transcipt_by = "transcrição por"
+speakers = "oradores"
+date = "data"
 
 lead = "Uma mina de ouro de transcrições associadas ao Bitcoin e à Lightning Network"
 section1_title = "Arqueologia do Bitcoin"

--- a/themes/ace-documentation/layouts/_default/single.html
+++ b/themes/ace-documentation/layouts/_default/single.html
@@ -3,6 +3,19 @@
 
 <h1>{{ .Title }}</h1>
 
+{{ if (.GetTerms "speakers") }}
+    <p>{{ i18n "speakers" | title }}:
+    {{ range $i, $e := .Params.speakers -}}
+        {{- if $i -}}, {{ end -}}
+        <a href='{{ "/speakers/" | relLangURL }}{{ . | urlize }}'>{{ $e }}</a>
+    {{- end -}}
+    </p>
+{{ end }}
+
+{{ if .Params.date }}
+    <p><i>{{ i18n "date" | title }}: {{ .Params.date.Format "January 2, 2006" }}</i></p>
+{{ end }}
+
 <p><i>{{ i18n "transcript_by" | title }}: {{ .Params.transcript_by }}</i></p>
 
 {{ if .Params.translation_by }}


### PR DESCRIPTION
We currently encourage the addition of `speaker: <speaker-name>` on metadata([front matter](https://gohugo.io/content-management/front-matter/)) but we don't actually support it. There is also variation on how contributors format the title, date and speakers names. Sometimes speakers names will be on the title, often together with the date. Sometimes data will be repeated twice, once on the metadata and then in the content of the transcript. 

This PR adds support for extra metadata related to speakers and date to allow for

1.  Better contribution guidelines on the format of title, speakers names and date.
2. Filtering by speaker the same way filtering by tag and category works.
3. Pave the way for filtering by date.

This change is backwards compatible and doesn't break current transcripts. It enables this for future contributions but current transcripts will need manual changes in their metadata in order to support this.

This is how a transcript will be displayed with the addition of the new `speakers` and `date` metadata fields
```
---
speakers: ['Speaker1', 'Speaker2']
date: YYYY-MM-DD
---
```
<img src="https://user-images.githubusercontent.com/18506343/172894917-79a19737-07f0-4458-90ce-0431ae428986.png" width=80% height=80%/>

