### PR TITLE
add script to make transcript preview easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,13 @@ To build locally, you first need to install Hugo, take a look at the [Hugo insta
 
 ### Preview your transcript
 
-Having a local build allows you to see how your transcript will be displayed in the website. You can do that by using the branch containing your transcript as the content submodule.
+Having a local build allows you to see how your transcript will be displayed in the website.
 
-Make sure that your transcript is at `<transcript-branch>` at `<your-repository-fork>` of the [bitcointranscripts repository](https://github.com/bitcointranscripts/bitcointranscripts) and run: 
+The `preview_branch.sh` script allows you to preview how the changes in your branch will be displayed by building locally the website using your branch as the content submodule. Usage:
 
-- `git submodule set-url content <your-repository-fork>` to change the submodule url
-- `git submodule set-branch --branch <transcript-branch> content` to change the submodule branch (default is master)
-- `git submodule update --remote` to fetch the updated submodule content
-- `hugo server` to build the website with the updated content
-
-To reset back to using the original submodule, run:
-
-- `git restore .gitmodules`
-- `git submodule update`
+```
+./preview_branch.sh <your-github-account> <your-branch-name>
+```
 
 ## i18n
 

--- a/preview_branch.sh
+++ b/preview_branch.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script allows you to preview how the changes in your branch will be displayed in the website.
+
+# By giving as arguments your GitHub username and the branch you want to preview, Hugo will locally
+# build the website using your branch as the content submodule.
+# Usage example: ./preview_branch.sh <your-github-account> <your-branch-name>
+
+# You can see the preview at http://localhost:1313 and after you close the preview, the script will
+# handle the reset back to using the original submodule
+
+GITHUB_ACCOUNT=$1
+REPOSITORY_FORK="https://github.com/${GITHUB_ACCOUNT}/bitcointranscripts.git"
+BRANCH=${2:-"master"}
+
+# On exit always reset back to using the original submodule and revert any changes done in preview-mode
+trap 'git restore .gitmodules; git submodule update -f' EXIT
+
+# Preview mode
+echo "Previewing branch '${BRANCH}' of '${REPOSITORY_FORK}':"
+(git submodule set-url content "$REPOSITORY_FORK" &&       # change the submodule url
+    git submodule set-branch --branch "$BRANCH" content && # change the submodule branch
+    git submodule update --remote) &&                      # fetch the updated submodule content
+    hugo server                                            # build the website with the updated content


### PR DESCRIPTION
replace the step-by-step commands for transcript preview with `preview_branch` script
to make the process easier for non-technical people

This is not the best solution, my ideal solution would be to have a temporary preview of the website every time someone opens a PR (kind of how Bitcoin Optech does it), but until then, this is a simple alternative.
 
To encourage contributors to preview their changes, instead of every time running 6 commands, this script allows the same process with a single simpler command.

**Usage example:**
Let's say I want to preview the currently open https://github.com/bitcointranscripts/bitcointranscripts/pull/169. I only need to run `./preview_branch.sh BlueeeMoon meeting-notes` and Hugo will locally build the website using the PR branch as the content submodule. I will then see the preview at `http://localhost:1313` and after terminating Hugo, the script will handle the reset back to using the original submodule.