### PR TITLE
fix alphabetical sorting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,6 @@ baseURL = "https://btctranscripts.com/"
 languageCode = "en-us"
 
 theme = "ace-documentation"
-orderSectionsby = "title"
 ignoreFiles = [ "README.md", "LICENSE.md" ]
 
 DefaultContentLanguage = "en"
@@ -31,6 +30,7 @@ DefaultContentLanguage = "en"
     page = [ "HTML"]
 
 [params]
+    ordersectionsby = "title"
     disableReadmoreNav = true
     menushortcutsnewtab = false
     custom_js = ["js/custom.js"]

--- a/themes/ace-documentation/layouts/shortcodes/childpages.html
+++ b/themes/ace-documentation/layouts/shortcodes/childpages.html
@@ -1,4 +1,4 @@
-{{- $sortTerm :=  .Get "sort" | default "Weight" }}
+{{- $sortTerm :=  .Get "sort" | default "Title" }}
 
 {{- .Scratch.Set "current" .Page }}
 
@@ -18,8 +18,8 @@
     {{- end}}
     {{- $pages := (.Scratch.Get "pages") }}
 
-	{{- if eq $sortTerm "Weight"}}
-		{{- template "childs" dict "menu" $pages.ByWeight "pages" .Site.Pages "sortTerm" $sortTerm}}
+	{{- if eq $sortTerm "Title"}}
+		{{- template "childs" dict "menu" $pages.ByTitle "pages" .Site.Pages "sortTerm" $sortTerm}}
 	{{end}}
 </ul>
 


### PR DESCRIPTION
Closes https://github.com/bitcointranscripts/bitcointranscripts.github.io/issues/45 as an alternative to https://github.com/bitcointranscripts/bitcointranscripts/pull/188 to also keep the date taxonomy

Default sorting in Hugo is defined by
Weight > Date > LinkTitle > FilePath ([src](https://gohugo.io/templates/lists/#order-content))
thus adding dates broke the behavior.

This fixes sorting back to alphabetical 
![Screenshot 2022-08-17 at 9 46 10 AM](https://user-images.githubusercontent.com/18506343/185052766-d3538230-30f1-420a-9865-4f5b231d2bbc.png)

