### PR TITLE
fix child pages regression

### DIFF
--- a/themes/ace-documentation/layouts/_default/single.html
+++ b/themes/ace-documentation/layouts/_default/single.html
@@ -40,6 +40,12 @@
     </p>
 {{ end }}
 
+{{ if .Params.media }}
+    <p>Media: 
+        <a href='{{ .Params.media }}'>{{ .Params.media }}</a>
+    </p>
+{{ end }}
+
 {{ .Content }}
 
     {{ if .IsTranslated }}

--- a/themes/ace-documentation/layouts/partials/head.html
+++ b/themes/ace-documentation/layouts/partials/head.html
@@ -22,7 +22,7 @@
 
     <!-- Only include the tracking when using `hugo` or adding `--environment production` -->
     {{ if eq hugo.Environment "production" }}
-        {{ template "_internal/twitter_cards.html" . }}
+        {{- partial "twitter_cards.html" . -}}
     {{ end }}
 
 </head>

--- a/themes/ace-documentation/layouts/partials/twitter_cards.html
+++ b/themes/ace-documentation/layouts/partials/twitter_cards.html
@@ -1,0 +1,29 @@
+<!-- adapted from https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/twitter_cards.html -->
+{{- with $.Params.images -}}
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:image" content="{{ index . 0 | absURL }}"/>
+{{ else -}}
+{{- $images := $.Resources.ByType "image" -}}
+{{- $featured := $images.GetMatch "*feature*" -}}
+{{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+{{- with $featured -}}
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:image" content="{{ $featured.Permalink }}"/>
+{{- else -}}
+{{- with $.Site.Params.images -}}
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:image" content="{{ index . 0 | absURL }}"/>
+{{ else -}}
+<meta name="twitter:card" content="summary"/>
+{{- end -}}
+{{- end -}}
+{{- end }}
+{{ if (.GetTerms "speakers") }}
+<meta name="twitter:title" content='{{ delimit (.Params.speakers) ", " }} - {{ .Title }}'/>
+{{ else }}
+<meta name="twitter:title" content="{{ .Title }}"/>
+{{ end }} 
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
+{{ with .Site.Social.twitter -}}
+<meta name="twitter:site" content="@{{ . }}"/>
+{{ end -}}

--- a/themes/ace-documentation/layouts/shortcodes/childpages.html
+++ b/themes/ace-documentation/layouts/shortcodes/childpages.html
@@ -28,7 +28,12 @@
 {{ define "childs" }}
 		{{- range .menu }}
 			<li class="h6 child-links py-1">
-				<a href="{{.RelPermalink}}"> {{ .Title }} </a>
+				<a href="{{.RelPermalink}}"> 
+					{{ if (.GetTerms "speakers") }}
+						{{ delimit (.Params.speakers) ", " }} - 
+					{{ end }} 
+					{{ .Title }} 
+				</a>
 			</li>
 		{{ end }}
 {{ end }}


### PR DESCRIPTION
After https://github.com/bitcointranscripts/bitcointranscripts/pull/214 speakers' name have been moved from the transcript's title to its metadata, which means less displayed information when navigating through the pages:
![Screenshot 2023-01-11 at 8 10 35 PM](https://user-images.githubusercontent.com/18506343/211884803-9639b0e2-ed36-422b-96c1-43a923c449f8.png)

There is a potential UI update on the horizon, but until then, this PR takes us back to the previous format "speaker - title":
![Screenshot 2023-01-11 at 9 43 36 PM](https://user-images.githubusercontent.com/18506343/211902616-bdad6627-d498-4ef8-82bb-0e04d6810f98.png)

I've also cherry-pick some changes from https://github.com/bitcointranscripts/bitcointranscripts.github.io/pull/49:

- 3014bd4a4ad7ac7f1d678edd58dc152d87395748: uses the speakers' metadata to display the speakers' names on the twitter card preview when a transcript is shared on twitter.
- ce0386fbff2a8ca7378e9dda5987ec6378348d94: `media` metadata have been introduced with https://github.com/bitcointranscripts/bitcointranscripts/pull/213 but are not yet displayed in the website, this adds support.