### PR TITLE
Mirror the Optech topic-categories structure in the `/tags` page

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
           extended: true
 
       - name: Build
-        run: hugo --minify
+        run: hugo -s prebuild && hugo --minify
         env:
           HUGO_UMAMI_SOURCE: ${{ secrets.HUGO_UMAMI_SOURCE }}
           HUGO_UMAMI_WEBSITE_ID: "${{ secrets.HUGO_UMAMI_WEBSITE_ID }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.DS_Store
 .vscode
 .hugo_build.lock
+
+/prebuild/public

--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,10 @@ DefaultContentLanguage = "en"
     source = "prebuild/public/tags"
     target = "content/tags"
 
+  [[module.mounts]]
+    source = "tags"
+    target = "content/tags"
+
 [languages]
   [languages.en]
     title = "₿itcoin Transcripts"

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,15 @@ DefaultContentLanguage = "en"
   tag = 'tags'
   speaker = 'speakers'
 
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+
+  [[module.mounts]]
+    source = "prebuild/public/tags"
+    target = "content/tags"
+
 [languages]
   [languages.en]
     title = "₿itcoin Transcripts"

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -1,0 +1,74 @@
+{{ define "main" }}
+{{ $uniqueCategories := slice }}
+{{ $tags := .Data.Pages }}
+{{ $termsWithoutCategories := slice }}
+
+{{ range $tags }}
+    {{ $categories := .Params.categories }}
+    {{ if $categories }}
+        {{ range $categories }}
+            {{ $uniqueCategories = $uniqueCategories | append . }}
+        {{ end }}
+    {{ else }}
+        {{ $termsWithoutCategories = $termsWithoutCategories | append . }}
+    {{ end }}
+{{ end }}
+
+{{ $uniqueCategories = $uniqueCategories | uniq | sort }}
+{{ $termsWithoutCategories = $termsWithoutCategories }}
+
+<div class="tag-header">
+    <h1>Tags</h1>
+    <p>
+        <em>{{ len $uniqueCategories }} categories for {{ len $tags }} unique
+            tags, with many appearing in multiple categories.</em>
+    </p>
+    <p class="categories">
+        {{ range $index, $category := $uniqueCategories -}}
+            <a href="#{{ urlize $category}}">{{ $category }}</a>
+            &nbsp;|&nbsp;
+        {{ end }}
+        <a href="#misc">Misc</a>
+    </p>
+</div>
+
+<div class="main categories-container">
+<!-- iterate over all the unique categories to display under them the
+tags that are assigned to those categories -->
+{{ range $uniqueCategories }}
+    <h3 id="{{ urlize . }}">{{ . }}</h3>
+    <ul>
+        {{ $currentCategory := . }}
+        {{ $categoryPermalink := "" }}
+        <!-- iterate over all the tags to check if
+        they are part of the current category -->
+        {{ range sort $tags "Title" "asc" }}
+            <!-- check if the current tag is part of the current category -->
+            {{ if in .Params.categories $currentCategory}}
+                <!-- check if the title of the tag matches the category's name -->
+                {{ if in .Params.title $currentCategory }}
+                    <!-- content can be assigned directly to the general category
+                    this check is how we detect if content has been assigned to the general category -->
+                    {{ $categoryPermalink = .Permalink }}
+                {{ else }}
+                    <!-- current tag belongs to the current category -->
+                    <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+                {{ end }}
+            {{ end }}
+        {{ end }}
+        <!-- Add a misc item for content assign to the general category -->
+        {{ if $categoryPermalink }}
+            <li><a href="{{ $categoryPermalink }}">Miscellaneous</a></li>
+        {{ end }}
+    </ul>
+{{ end }}
+
+<!-- General Category for Terms without Categories -->
+<h3 id="misc">Misc</h3>
+<ul>
+    {{ range sort $termsWithoutCategories "Title" "asc" }}
+        <li><a href="{{ .Permalink }}">{{ .Title | humanize | title }}</a></li>
+    {{ end }}
+</ul>
+</div>
+{{ end }}

--- a/prebuild/config.yaml
+++ b/prebuild/config.yaml
@@ -1,0 +1,7 @@
+disableKinds:
+- sitemap
+- taxonomy
+- term
+outputs:
+  home:
+  - html

--- a/prebuild/layouts/index.html
+++ b/prebuild/layouts/index.html
@@ -1,0 +1,9 @@
+{{ with resources.GetRemote "https://www.kouloumos.com/topics.json" }}
+  {{ $topics := unmarshal .Content }}
+  {{ range $topics }}
+    {{/* 1. */}} {{ $string := jsonify . }}
+    {{/* 2. */}} {{ $filename := printf "tags/%s/_index.md" (urlize .slug) }} 
+    {{/* 3. */}} {{ $resource := resources.FromString $filename $string }} 
+    {{/* 4. */}} {{ $file := $resource.RelPermalink }} 
+  {{ end }}
+{{ end }}

--- a/tags/bandwidth-reduction/_index.md
+++ b/tags/bandwidth-reduction/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Bandwidth Reduction"
+categories: ["Bandwidth Reduction"]
+---

--- a/tags/consensus-enforcement/_index.md
+++ b/tags/consensus-enforcement/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Consensus Enforcement"
+categories: ["Consensus Enforcement"]
+---

--- a/tags/contract-protocols/_index.md
+++ b/tags/contract-protocols/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Contract Protocols"
+categories: ["Contract Protocols"]
+---

--- a/tags/developer-tools/_index.md
+++ b/tags/developer-tools/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Developer Tools"
+categories: ["Developer Tools"]
+---

--- a/tags/fee-management/_index.md
+++ b/tags/fee-management/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Fee Management"
+categories: ["Fee Management"]
+---

--- a/tags/lightning/_index.md
+++ b/tags/lightning/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Lightning Network"
+categories: ["Lightning Network"]
+---

--- a/tags/lightweight-client/_index.md
+++ b/tags/lightweight-client/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Lightweight Client Support"
+categories: ["Lightweight Client Support"]
+---

--- a/tags/mining/_index.md
+++ b/tags/mining/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Mining"
+categories: ["Mining"]
+---

--- a/tags/p2p/_index.md
+++ b/tags/p2p/_index.md
@@ -1,0 +1,4 @@
+---
+title: "P2P Network Protocol"
+categories: ["P2P Network Protocol"]
+---

--- a/tags/privacy-enhancements/_index.md
+++ b/tags/privacy-enhancements/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Privacy Enhancements"
+categories: ["Privacy Enhancements"]
+---

--- a/tags/privacy-problems/_index.md
+++ b/tags/privacy-problems/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Privacy Problems"
+categories: ["Privacy Problems"]
+---

--- a/tags/scripts-addresses/_index.md
+++ b/tags/scripts-addresses/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Scripts and Addresses"
+categories: ["Scripts and Addresses"]
+---

--- a/tags/security-enhancements/_index.md
+++ b/tags/security-enhancements/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Security Enhancements"
+categories: ["Security Enhancements"]
+---

--- a/tags/security-problems/_index.md
+++ b/tags/security-problems/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Security Problems"
+categories: ["Security Problems"]
+---

--- a/tags/transaction-relay-policy/_index.md
+++ b/tags/transaction-relay-policy/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Transaction Relay Policy"
+categories: ["Transaction Relay Policy"]
+---

--- a/themes/ace-documentation/assets/css/ace.scss
+++ b/themes/ace-documentation/assets/css/ace.scss
@@ -182,3 +182,17 @@ img {
     padding-inline: 10px;
     background-color: #CCCCCC;
 }
+.tag-header {
+    padding: 0px 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.categories {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.categories-container {
+    padding: 0px 40px;
+}

--- a/themes/ace-documentation/assets/css/ace.scss
+++ b/themes/ace-documentation/assets/css/ace.scss
@@ -171,12 +171,13 @@ img {
 }
 .tags-container {
     display: flex;
+    flex-wrap: wrap;
     margin-top: 5px;
+    gap: 5px;
 }
 .tag {
     text-transform: uppercase;
     font-size: 0.7em;
-    margin-right: 5px;
     border-radius: 8px;
     padding: 4px;
     padding-inline: 10px;
@@ -195,4 +196,17 @@ img {
 }
 .categories-container {
     padding: 0px 40px;
+}
+.taxonomy-list {
+    padding-right: 40px;
+}
+.aliases {
+    font-style: italic;
+}
+.excerpt {
+    margin-bottom: 15px;
+    line-height: 1.5;
+}
+.source-info {
+    font-size: 0.8em;
 }

--- a/themes/ace-documentation/layouts/_default/baseof.html
+++ b/themes/ace-documentation/layouts/_default/baseof.html
@@ -22,7 +22,7 @@
                     {{- partial "menu.html" . -}}
                 </div>
 
-                {{- if and (ne .Site.Params.toc false) (ne .Params.toc false) (ne .IsHome true) }}
+                {{- if and (ne .Site.Params.toc false) (ne .Params.toc false) (ne .IsHome true) (ne .Kind "taxonomy" true) (ne .Kind "term" true) }}
                 <div class="docs-toc large order-lg-2 order-md-0 order-xs-1 col-12 col-lg-2 col-xl-2 position-sticky">
                     {{- partial "tableofcontents.html" . -}}
                 </div>

--- a/themes/ace-documentation/layouts/_default/taxonomy.html
+++ b/themes/ace-documentation/layouts/_default/taxonomy.html
@@ -1,21 +1,46 @@
 {{ define "main" }}
 
-<h1>{{ .Title | humanize | title }}</h1>
-
-<ul>
+<div class="tag-header">
+{{ if .Params.optech_url }}
+    <h1>{{ .Title }}</h1>
+{{ else }}
+    <h1>{{ .Title | humanize | title }}</h1>
+{{ end }}
+{{ with .Params.aliases }}
+<p>
+    <em>
+        Also covering 
+        {{ range $i, $e := . -}}
+            {{- if $i -}}, {{ end -}}
+            {{ $e }}
+        {{- end -}}
+    </em>
+</p>
+{{ end }}
+{{ if .Params.excerpt }}
+    <div class="excerpt">
+        {{ .Params.excerpt | markdownify }}
+        {{ with .Params.optech_url }}
+            <span class="source-info"><a href="{{ . }}">Read More</a></span>
+        {{ end }}
+    </div>
+{{ end }}
+</div>
+{{ if gt (len .Data.Pages) 0 }}
+<ul class="taxonomy-list">
     {{ range .Data.Pages }}
     <div class="h6 child-links py-1">
         <a href="{{.RelPermalink}}" class="list-group-item list-group-item-action flex-column align-items-start">
-            <div class="d-flex justify-content-between">
+            <div class="d-flex flex-wrap-reverse justify-content-between">
                 <h5 class="mb-1">{{ .Title }} </h5>
-                <small class="pl-1 text-muted font-italic align-self-start" style="white-space: nowrap;">{{ .Params.date.Format "Jan 02, 2006" }}</small>
+                <small class="text-muted font-italic ml-auto" style="white-space: nowrap;">{{ .Params.date.Format "Jan 02, 2006" }}</small>
             </div>
             {{ with .Params.speakers }}
 			    <p class="mb-1 text-muted">{{ delimit . ", " }}</p>
 			{{ end }}
-            <div class="d-flex justify-content-between">
+            <div class="d-flex flex-wrap justify-content-between">
                 {{ template "tags" . }}
-                <small class="text-muted font-italic align-self-end" style="white-space: nowrap;">
+                <small class="text-muted font-italic align-self-end ml-auto" style="padding-top: 7px;">
                     {{ trim .File.Dir "/" }}
                 </small>
             </div>
@@ -23,6 +48,9 @@
     </div>
     {{ end }}
 </ul>
+{{ else }}
+  <p style="padding: 20px; text-align: center;">No transcripts available for this tag yet.</p>
+{{ end }}
 
     {{ if .IsTranslated }}
         <h4>{{ i18n "translations" }}</h4>


### PR DESCRIPTION
This PR is the next step to the effort to refine the tags based on the well-thought-out [Bitcoin Optech Topics](https://bitcoinops.org/en/topics/) for better transcripts' categorization. The first step was https://github.com/bitcointranscripts/bitcointranscripts/pull/386.

This next step mirrors the [Optech topic-categories structure](https://bitcoinops.org/en/topic-categories/) in the `/tags` page.
![image](https://github.com/bitcointranscripts/bitcointranscripts.github.io/assets/18506343/8d3dd832-691d-42a5-a118-65129f190d60)

This change is based on a [proposed change to the Optech website](https://github.com/bitcoinops/bitcoinops.github.io/pull/1491) to export topics as JSON, allowing seamless utilization by anyone, including us. After that change, the topics (alongside their metadata) will be available at `https://bitcoinops.org/topics.json` from where we fetch the topics and initialize tags for each one of them as part of the prebuild step (7acb4ed9dad8c75575f6941f64dd43820a21bc0b). For now, as the change is not yet merged to [bitcoinops/bitcoinops.github.io](https://github.com/bitcoinops/bitcoinops.github.io) we are using https://www.kouloumos.com/topics.json as the source of the prebuild step. 

Additionally we are using the different categories (that Optech Topics are assigned to) as general categories to which we assign transcripts that don't match a specific tag/topic. Those, if exist, can be found at the end of the list of each category under "Miscellaneous".

Finally, as we already have some useful metadata for each Optech Topic, we are displaying them inside of each tag's page to give more context to the reader during content discovery.
![image](https://github.com/bitcointranscripts/bitcointranscripts.github.io/assets/18506343/404bc53c-4b39-4fe6-87c1-db7dee8068fb)
