### PR TITLE
feat: dispatch event to registry repo

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,3 +31,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+
+      - name: Trigger dependent repo update submodule
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.DISPATCH_UPDATE_REGISTRY_GH_PAGES }}" \
+          -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/bitcointranscripts/registry/dispatches \
+          -d '{"event_type": "update_submodules"}'


### PR DESCRIPTION
Dispatch custom event to [new registry repo](https://github.com/bitcointranscripts/registry) after successful deploy.

[New registry](https://github.com/bitcointranscripts/registry) is dependent on `gh-pages` branch and must be kept up to date.

secrets: `DISPATCH_UPDATE_REGISTRY_GH_PAGES`
This secret should be created by any user with write permission in [new registry](https://github.com/bitcointranscripts/registry) repo and it is used to authenticate the repository dispatch request